### PR TITLE
Missing button in the spark-auth.html file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The HTML page must be served from a web browser (vs. the local file system)
 
 ## Usage
 
-- Register a Spark application at https://dev-preview.ciscospark.com/apps.html
+- Register a Spark application at https://developer.ciscospark.com/apps.html
 - Note, the application URL provided during registration should be the URL where this sample app page will be hosted
 - The application Client ID and Client Secret generated during registration are required to run the app
 

--- a/spark-auth.html
+++ b/spark-auth.html
@@ -115,7 +115,7 @@ textarea {height: 140px;}
 			</tr>
 			<tr>
 				<td>Redirect URI:</td> 
-				<td><input id="redirectUri"/></td>
+				<td><input id="redirectUri"/><button name="codeButton" type="button" onClick="codeClick()">Request Auth Code</button></td>
 			</tr>
 		</table>
 	</div>


### PR DESCRIPTION
ps. desc. is copied from tropo-banking-sample
